### PR TITLE
just launch offline on hard fail

### DIFF
--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -141,7 +141,8 @@ void MSAStep::onOAuthActivityChanged(Katabasis::Activity activity) {
         }
         case Katabasis::Activity::FailedHard: {
             emit hideVerificationUriAndCode();
-            emit finished(AccountTaskState::STATE_FAILED_HARD, tr("Microsoft user authentication failed."));
+            emit finished(AccountTaskState::STATE_OFFLINE, tr("Microsoft user authentication ended with a network error."));
+            //emit finished(AccountTaskState::STATE_FAILED_HARD, tr("Microsoft user authentication failed."));
             return;
         }
         default: {


### PR DESCRIPTION
Clicking `play offline` on a MS account will not work.
While clicking `play` or `play offline` on a offline account works fine.

https://user-images.githubusercontent.com/1879846/166297037-5a34885e-6aa8-4ab9-97d8-d78f5cd20535.mp4

i haven't touched cpp in years so got no clue what the proper fix    
the pr just launches hard failsiures in offline mode instead