### PR TITLE
Remove PolyMC MSA Client ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ set(Launcher_META_URL "https://meta.polymc.org/v1/" CACHE STRING "URL to fetch L
 set(Launcher_IMGUR_CLIENT_ID "5b97b0713fba4a3" CACHE STRING "Client ID you can get from Imgur when you register an application")
 
 # MSA Client ID
-set(Launcher_MSA_CLIENT_ID "549033b2-1532-4d4e-ae77-1bbaa46f9d74" CACHE STRING "Client ID you can get from Microsoft Identity Platform when you register an application")
+set(Launcher_MSA_CLIENT_ID "" CACHE STRING "Client ID you can get from Microsoft Identity Platform when you register an application")
 
 # CurseForge API Key
 # CHANGE THIS IF YOU FORK THIS PROJECT!


### PR DESCRIPTION
This is a polite request to please respect PolyMC and not use PolyMC's official MSA client ID for such a fork, we don't want to get it disabled by M$ since we have to play by their rules to be able to use the identity service.

If you need help getting your own client ID in order to be responsible for your fork's usage of the platform then I can ask someone to help you with that. Although, by the readme it seems you don't want to deal with Microsoft's BS so it might be better to just remove the client ID altogether like this PR currently does.

Thanks.